### PR TITLE
Add PATCH HTTP method

### DIFF
--- a/Hippolyte/StubRequest.swift
+++ b/Hippolyte/StubRequest.swift
@@ -5,7 +5,7 @@
 import Foundation
 
 public enum HTTPMethod: String {
-  case GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE
+  case GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH
 }
 
 public struct StubRequest: Hashable {


### PR DESCRIPTION
Hi @JanGorman and contributors,

Thank you for this nice and simple HTTP stubbing library!

This PR adds the PATCH HTTP method to the `HTTPMethod` enum in `StubRequest.swift`, so we can stub PATCH requests.

I hope this change makes sense. The tests ran successfully (on my machine) and I've been able to stub PATCH requests using this change.

Best regards,
Steven