### PR TITLE
Added macOS scheme and targets to Xcode project to support building for macOS using Carthage

### DIFF
--- a/Hippolyte.xcodeproj/project.pbxproj
+++ b/Hippolyte.xcodeproj/project.pbxproj
@@ -26,6 +26,25 @@
 		77A2EA9F1F6561A30051E45A /* HippolyteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A2EA9E1F6561A30051E45A /* HippolyteTests.swift */; };
 		77B806641F63E33A0077A365 /* HTTPStubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B806631F63E33A0077A365 /* HTTPStubURLProtocol.swift */; };
 		77B806661F63E5670077A365 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B806651F63E5670077A365 /* HTTPRequest.swift */; };
+		E64B0ED3223ACCF900FB35E4 /* Hippolyte.h in Headers */ = {isa = PBXBuildFile; fileRef = 77A290D11F62EADF001E70FA /* Hippolyte.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E64B0ED4223ACD0D00FB35E4 /* Hippolyte.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A290E81F62EDF5001E70FA /* Hippolyte.swift */; };
+		E64B0ED5223ACD0D00FB35E4 /* StubRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A290EA1F62EE40001E70FA /* StubRequest.swift */; };
+		E64B0ED6223ACD0D00FB35E4 /* StubResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A290EC1F62EEC2001E70FA /* StubResponse.swift */; };
+		E64B0ED7223ACD0D00FB35E4 /* HTTPClientHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A290EE1F62F13E001E70FA /* HTTPClientHook.swift */; };
+		E64B0ED8223ACD0D00FB35E4 /* URLSessionHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A290F01F62F241001E70FA /* URLSessionHook.swift */; };
+		E64B0ED9223ACD0D00FB35E4 /* HTTPStubURLProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B806631F63E33A0077A365 /* HTTPStubURLProtocol.swift */; };
+		E64B0EDA223ACD0D00FB35E4 /* HTTPRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77B806651F63E5670077A365 /* HTTPRequest.swift */; };
+		E64B0EDB223ACD0D00FB35E4 /* URLHook.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CF9D1F652D8F00B717B2 /* URLHook.swift */; };
+		E64B0EDC223ACD0D00FB35E4 /* Matcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CF9F1F652FD100B717B2 /* Matcher.swift */; };
+		E64B0EDD223ACD0D00FB35E4 /* URL+HippolyteAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CFA11F65311200B717B2 /* URL+HippolyteAdditions.swift */; };
+		E64B0EE8223ACE8400FB35E4 /* Hippolyte.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E64B0ECB223ACB6300FB35E4 /* Hippolyte.framework */; };
+		E64B0EEE223ACE9D00FB35E4 /* HippolyteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A2EA9E1F6561A30051E45A /* HippolyteTests.swift */; };
+		E64B0EEF223ACE9D00FB35E4 /* DataMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CFA31F654F1800B717B2 /* DataMatcherTests.swift */; };
+		E64B0EF0223ACE9D00FB35E4 /* StringMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CFA51F65515000B717B2 /* StringMatcherTests.swift */; };
+		E64B0EF1223ACE9D00FB35E4 /* RegexMatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CFA71F6552B100B717B2 /* RegexMatcherTests.swift */; };
+		E64B0EF2223ACE9D00FB35E4 /* StubRequestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7766CFAB1F65571800B717B2 /* StubRequestTests.swift */; };
+		E64B0EF3223ACE9D00FB35E4 /* StubResponseBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7706E6651F822F2C00734A1D /* StubResponseBuilderTests.swift */; };
+		E64B0EF4223ACE9D00FB35E4 /* TestRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77A2EA9C1F65589C0051E45A /* TestRequest.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +54,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 77A290CD1F62EADF001E70FA;
 			remoteInfo = Hippolyte;
+		};
+		E64B0EE9223ACE8400FB35E4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 77A290C51F62EADF001E70FA /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = E64B0ECA223ACB6300FB35E4;
+			remoteInfo = Hippolyte_macOS;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -61,6 +87,8 @@
 		77A2EA9E1F6561A30051E45A /* HippolyteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HippolyteTests.swift; sourceTree = "<group>"; };
 		77B806631F63E33A0077A365 /* HTTPStubURLProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPStubURLProtocol.swift; sourceTree = "<group>"; };
 		77B806651F63E5670077A365 /* HTTPRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPRequest.swift; sourceTree = "<group>"; };
+		E64B0ECB223ACB6300FB35E4 /* Hippolyte.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Hippolyte.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		E64B0EE3223ACE8400FB35E4 /* HippolyteTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = HippolyteTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -76,6 +104,21 @@
 			buildActionMask = 2147483647;
 			files = (
 				77A290D81F62EADF001E70FA /* Hippolyte.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E64B0EC8223ACB6300FB35E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E64B0EE0223ACE8400FB35E4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E64B0EE8223ACE8400FB35E4 /* Hippolyte.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -96,6 +139,8 @@
 			children = (
 				77A290CE1F62EADF001E70FA /* Hippolyte.framework */,
 				77A290D71F62EADF001E70FA /* HippolyteTests.xctest */,
+				E64B0ECB223ACB6300FB35E4 /* Hippolyte.framework */,
+				E64B0EE3223ACE8400FB35E4 /* HippolyteTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -145,12 +190,20 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E64B0EC6223ACB6300FB35E4 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E64B0ED3223ACCF900FB35E4 /* Hippolyte.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		77A290CD1F62EADF001E70FA /* Hippolyte */ = {
+		77A290CD1F62EADF001E70FA /* Hippolyte_iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 77A290E21F62EADF001E70FA /* Build configuration list for PBXNativeTarget "Hippolyte" */;
+			buildConfigurationList = 77A290E21F62EADF001E70FA /* Build configuration list for PBXNativeTarget "Hippolyte_iOS" */;
 			buildPhases = (
 				77A290C91F62EADF001E70FA /* Sources */,
 				77A290CA1F62EADF001E70FA /* Frameworks */,
@@ -162,14 +215,14 @@
 			);
 			dependencies = (
 			);
-			name = Hippolyte;
+			name = Hippolyte_iOS;
 			productName = Hippolyte;
 			productReference = 77A290CE1F62EADF001E70FA /* Hippolyte.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		77A290D61F62EADF001E70FA /* HippolyteTests */ = {
+		77A290D61F62EADF001E70FA /* HippolyteTests_iOS */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 77A290E51F62EADF001E70FA /* Build configuration list for PBXNativeTarget "HippolyteTests" */;
+			buildConfigurationList = 77A290E51F62EADF001E70FA /* Build configuration list for PBXNativeTarget "HippolyteTests_iOS" */;
 			buildPhases = (
 				77A290D31F62EADF001E70FA /* Sources */,
 				77A290D41F62EADF001E70FA /* Frameworks */,
@@ -180,9 +233,46 @@
 			dependencies = (
 				77A290DA1F62EADF001E70FA /* PBXTargetDependency */,
 			);
-			name = HippolyteTests;
+			name = HippolyteTests_iOS;
 			productName = HippolyteTests;
 			productReference = 77A290D71F62EADF001E70FA /* HippolyteTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		E64B0ECA223ACB6300FB35E4 /* Hippolyte_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E64B0ED0223ACB6300FB35E4 /* Build configuration list for PBXNativeTarget "Hippolyte_macOS" */;
+			buildPhases = (
+				E64B0EC6223ACB6300FB35E4 /* Headers */,
+				E64B0EC7223ACB6300FB35E4 /* Sources */,
+				E64B0EC8223ACB6300FB35E4 /* Frameworks */,
+				E64B0EC9223ACB6300FB35E4 /* Resources */,
+				E64B0EDE223ACD3100FB35E4 /* Run SwiftLint */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = Hippolyte_macOS;
+			productName = Hippolyte_Mac;
+			productReference = E64B0ECB223ACB6300FB35E4 /* Hippolyte.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		E64B0EE2223ACE8400FB35E4 /* HippolyteTests_macOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E64B0EEB223ACE8400FB35E4 /* Build configuration list for PBXNativeTarget "HippolyteTests_macOS" */;
+			buildPhases = (
+				E64B0EDF223ACE8400FB35E4 /* Sources */,
+				E64B0EE0223ACE8400FB35E4 /* Frameworks */,
+				E64B0EE1223ACE8400FB35E4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				E64B0EEA223ACE8400FB35E4 /* PBXTargetDependency */,
+			);
+			name = HippolyteTests_macOS;
+			productName = HippolyteTests_macOS;
+			productReference = E64B0EE3223ACE8400FB35E4 /* HippolyteTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
@@ -191,7 +281,7 @@
 		77A290C51F62EADF001E70FA /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0900;
+				LastSwiftUpdateCheck = 1010;
 				LastUpgradeCheck = 0930;
 				ORGANIZATIONNAME = "Jan Gorman";
 				TargetAttributes = {
@@ -203,6 +293,14 @@
 					77A290D61F62EADF001E70FA = {
 						CreatedOnToolsVersion = 9.0;
 						LastSwiftMigration = 1000;
+						ProvisioningStyle = Automatic;
+					};
+					E64B0ECA223ACB6300FB35E4 = {
+						CreatedOnToolsVersion = 10.1;
+						ProvisioningStyle = Automatic;
+					};
+					E64B0EE2223ACE8400FB35E4 = {
+						CreatedOnToolsVersion = 10.1;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -219,8 +317,10 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				77A290CD1F62EADF001E70FA /* Hippolyte */,
-				77A290D61F62EADF001E70FA /* HippolyteTests */,
+				77A290CD1F62EADF001E70FA /* Hippolyte_iOS */,
+				E64B0ECA223ACB6300FB35E4 /* Hippolyte_macOS */,
+				77A290D61F62EADF001E70FA /* HippolyteTests_iOS */,
+				E64B0EE2223ACE8400FB35E4 /* HippolyteTests_macOS */,
 			);
 		};
 /* End PBXProject section */
@@ -234,6 +334,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		77A290D51F62EADF001E70FA /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E64B0EC9223ACB6300FB35E4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E64B0EE1223ACE8400FB35E4 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -255,7 +369,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "#if which swiftlint >/dev/null; then\n#  swiftlint\n#fi";
+			shellScript = "#if which swiftlint >/dev/null; then\n#  swiftlint\n#fi\n";
+		};
+		E64B0EDE223ACD3100FB35E4 /* Run SwiftLint */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run SwiftLint";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "#if which swiftlint >/dev/null; then\n#  swiftlint\n#fi\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -291,13 +423,49 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E64B0EC7223ACB6300FB35E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E64B0ED8223ACD0D00FB35E4 /* URLSessionHook.swift in Sources */,
+				E64B0ED6223ACD0D00FB35E4 /* StubResponse.swift in Sources */,
+				E64B0ED4223ACD0D00FB35E4 /* Hippolyte.swift in Sources */,
+				E64B0ED5223ACD0D00FB35E4 /* StubRequest.swift in Sources */,
+				E64B0EDB223ACD0D00FB35E4 /* URLHook.swift in Sources */,
+				E64B0EDA223ACD0D00FB35E4 /* HTTPRequest.swift in Sources */,
+				E64B0EDD223ACD0D00FB35E4 /* URL+HippolyteAdditions.swift in Sources */,
+				E64B0ED7223ACD0D00FB35E4 /* HTTPClientHook.swift in Sources */,
+				E64B0EDC223ACD0D00FB35E4 /* Matcher.swift in Sources */,
+				E64B0ED9223ACD0D00FB35E4 /* HTTPStubURLProtocol.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		E64B0EDF223ACE8400FB35E4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E64B0EF1223ACE9D00FB35E4 /* RegexMatcherTests.swift in Sources */,
+				E64B0EF2223ACE9D00FB35E4 /* StubRequestTests.swift in Sources */,
+				E64B0EF3223ACE9D00FB35E4 /* StubResponseBuilderTests.swift in Sources */,
+				E64B0EF4223ACE9D00FB35E4 /* TestRequest.swift in Sources */,
+				E64B0EF0223ACE9D00FB35E4 /* StringMatcherTests.swift in Sources */,
+				E64B0EEF223ACE9D00FB35E4 /* DataMatcherTests.swift in Sources */,
+				E64B0EEE223ACE9D00FB35E4 /* HippolyteTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
 		77A290DA1F62EADF001E70FA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 77A290CD1F62EADF001E70FA /* Hippolyte */;
+			target = 77A290CD1F62EADF001E70FA /* Hippolyte_iOS */;
 			targetProxy = 77A290D91F62EADF001E70FA /* PBXContainerItemProxy */;
+		};
+		E64B0EEA223ACE8400FB35E4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = E64B0ECA223ACB6300FB35E4 /* Hippolyte_macOS */;
+			targetProxy = E64B0EE9223ACE8400FB35E4 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -354,6 +522,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -411,6 +580,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 9.3;
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
@@ -435,7 +605,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.Hippolyte;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = Hippolyte;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.2;
@@ -457,7 +627,7 @@
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.Hippolyte;
-				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				PRODUCT_NAME = Hippolyte;
 				SKIP_INSTALL = YES;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -472,7 +642,7 @@
 				INFOPLIST_FILE = HippolyteTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.HippolyteTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = HippolyteTests;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
@@ -486,9 +656,95 @@
 				INFOPLIST_FILE = HippolyteTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.HippolyteTests;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = HippolyteTests;
 				SWIFT_VERSION = 4.2;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E64B0ED1223ACB6300FB35E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Hippolyte/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.Hippolyte;
+				PRODUCT_NAME = Hippolyte;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		E64B0ED2223ACB6300FB35E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = Hippolyte/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = com.schnaub.Hippolyte;
+				PRODUCT_NAME = Hippolyte;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.2;
+			};
+			name = Release;
+		};
+		E64B0EEC223ACE8400FB35E4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = HippolyteTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.HippolyteTests-macOS";
+				PRODUCT_NAME = HippolyteTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
+			};
+			name = Debug;
+		};
+		E64B0EED223ACE8400FB35E4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CODE_SIGN_IDENTITY = "-";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = HippolyteTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
+				MTL_FAST_MATH = YES;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.schnaub.HippolyteTests-macOS";
+				PRODUCT_NAME = HippolyteTests;
+				SDKROOT = macosx;
+				SWIFT_VERSION = 4.2;
 			};
 			name = Release;
 		};
@@ -504,7 +760,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		77A290E21F62EADF001E70FA /* Build configuration list for PBXNativeTarget "Hippolyte" */ = {
+		77A290E21F62EADF001E70FA /* Build configuration list for PBXNativeTarget "Hippolyte_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				77A290E31F62EADF001E70FA /* Debug */,
@@ -513,11 +769,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		77A290E51F62EADF001E70FA /* Build configuration list for PBXNativeTarget "HippolyteTests" */ = {
+		77A290E51F62EADF001E70FA /* Build configuration list for PBXNativeTarget "HippolyteTests_iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				77A290E61F62EADF001E70FA /* Debug */,
 				77A290E71F62EADF001E70FA /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E64B0ED0223ACB6300FB35E4 /* Build configuration list for PBXNativeTarget "Hippolyte_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E64B0ED1223ACB6300FB35E4 /* Debug */,
+				E64B0ED2223ACB6300FB35E4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E64B0EEB223ACE8400FB35E4 /* Build configuration list for PBXNativeTarget "HippolyteTests_macOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E64B0EEC223ACE8400FB35E4 /* Debug */,
+				E64B0EED223ACE8400FB35E4 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Hippolyte.xcodeproj/xcshareddata/xcschemes/Hippolyte_iOS.xcscheme
+++ b/Hippolyte.xcodeproj/xcshareddata/xcschemes/Hippolyte_iOS.xcscheme
@@ -1,0 +1,100 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0930"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+               BuildableName = "Hippolyte.framework"
+               BlueprintName = "Hippolyte_iOS"
+               ReferencedContainer = "container:Hippolyte.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      codeCoverageEnabled = "YES"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "77A290D61F62EADF001E70FA"
+               BuildableName = "HippolyteTests.xctest"
+               BlueprintName = "HippolyteTests_iOS"
+               ReferencedContainer = "container:Hippolyte.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BuildableName = "Hippolyte.framework"
+            BlueprintName = "Hippolyte_iOS"
+            ReferencedContainer = "container:Hippolyte.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BuildableName = "Hippolyte.framework"
+            BlueprintName = "Hippolyte_iOS"
+            ReferencedContainer = "container:Hippolyte.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BuildableName = "Hippolyte.framework"
+            BlueprintName = "Hippolyte_iOS"
+            ReferencedContainer = "container:Hippolyte.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Hippolyte.xcodeproj/xcshareddata/xcschemes/Hippolyte_macOS.xcscheme
+++ b/Hippolyte.xcodeproj/xcshareddata/xcschemes/Hippolyte_macOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0930"
+   LastUpgradeVersion = "1010"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,9 +14,9 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+               BlueprintIdentifier = "E64B0ECA223ACB6300FB35E4"
                BuildableName = "Hippolyte.framework"
-               BlueprintName = "Hippolyte"
+               BlueprintName = "Hippolyte_macOS"
                ReferencedContainer = "container:Hippolyte.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -26,16 +26,15 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "77A290D61F62EADF001E70FA"
+               BlueprintIdentifier = "E64B0EE2223ACE8400FB35E4"
                BuildableName = "HippolyteTests.xctest"
-               BlueprintName = "HippolyteTests"
+               BlueprintName = "HippolyteTests_macOS"
                ReferencedContainer = "container:Hippolyte.xcodeproj">
             </BuildableReference>
          </TestableReference>
@@ -43,9 +42,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BlueprintIdentifier = "E64B0ECA223ACB6300FB35E4"
             BuildableName = "Hippolyte.framework"
-            BlueprintName = "Hippolyte"
+            BlueprintName = "Hippolyte_macOS"
             ReferencedContainer = "container:Hippolyte.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -65,9 +64,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BlueprintIdentifier = "E64B0ECA223ACB6300FB35E4"
             BuildableName = "Hippolyte.framework"
-            BlueprintName = "Hippolyte"
+            BlueprintName = "Hippolyte_macOS"
             ReferencedContainer = "container:Hippolyte.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -83,9 +82,9 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "77A290CD1F62EADF001E70FA"
+            BlueprintIdentifier = "E64B0ECA223ACB6300FB35E4"
             BuildableName = "Hippolyte.framework"
-            BlueprintName = "Hippolyte"
+            BlueprintName = "Hippolyte_macOS"
             ReferencedContainer = "container:Hippolyte.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/Hippolyte/Hippolyte.h
+++ b/Hippolyte/Hippolyte.h
@@ -6,7 +6,7 @@
 //  Copyright © 2017 Jan Gorman. All rights reserved.
 //
 
-#import <UIKit/UIKit.h>
+@import Foundation;
 
 //! Project version number for Hippolyte.
 FOUNDATION_EXPORT double HippolyteVersionNumber;

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ An HTTP stubbing library written in Swift.
 
 - Swift 4.2
 - iOS 9.3+
+- macOS 10.13+
 - Xcode 10+
 
 ## Install


### PR DESCRIPTION
# Schemes

Modified: `Hippolyte` → `Hippolyte_iOS`
Added: `Hippolyte_macOS`

# Targets

Modified: `Hippolyte` → `Hippolyte_iOS`
Modified: `HippolyteTests` → `HippolyteTests_iOS`
Added: `Hippolyte_macOS`
Added: `HippolyteTests_macOS`

# Products

No change: `Hippolyte.framework` (inside iOS `Products` folder)
No change: `HippolyteTests.xctest` (inside iOS `Products` folder)
Added: `Hippolyte.framework` (inside macOS `Products` folder)
Added: `HippolyteTests.xctest` (inside macOS `Products` folder)