### PR TITLE
added @discardableResult to Builder methods

### DIFF
--- a/Hippolyte/StubRequest.swift
+++ b/Hippolyte/StubRequest.swift
@@ -17,23 +17,23 @@ public struct StubRequest: Hashable {
     public init() {
     }
 
-    public func stubRequest(withMethod method: HTTPMethod, url: URL) -> Builder {
+    @discardableResult public func stubRequest(withMethod method: HTTPMethod, url: URL) -> Builder {
       request = StubRequest(method: method, url: url)
       return self
     }
 
-    public func stubRequest(withMethod method: HTTPMethod, urlMatcher: Matcher) -> Builder {
+    @discardableResult public func stubRequest(withMethod method: HTTPMethod, urlMatcher: Matcher) -> Builder {
       request = StubRequest(method: method, urlMatcher: urlMatcher)
       return self
     }
 
-    public func addHeader(withKey key: String, value: String) -> Builder {
+    @discardableResult public func addHeader(withKey key: String, value: String) -> Builder {
       assert(request != nil)
       request.setHeader(key: key, value: value)
       return self
     }
 
-    public func addResponse(_ response: StubResponse) -> Builder {
+    @discardableResult public func addResponse(_ response: StubResponse) -> Builder {
       assert(request != nil)
       request.response = response
       return self

--- a/Hippolyte/StubResponse.swift
+++ b/Hippolyte/StubResponse.swift
@@ -19,28 +19,28 @@ public struct StubResponse: HTTPStubResponse, Equatable {
     public init() {
     }
 
-    public func defaultResponse() -> Builder {
+    @discardableResult public func defaultResponse() -> Builder {
       response = StubResponse()
       return self
     }
 
-    public func stubResponse(withStatusCode statusCode: Int) -> Builder {
+    @discardableResult public func stubResponse(withStatusCode statusCode: Int) -> Builder {
       response = StubResponse(statusCode: statusCode)
       return self
     }
 
-    public func stubResponse(withError error: NSError) -> Builder {
+    @discardableResult public func stubResponse(withError error: NSError) -> Builder {
       response = StubResponse(error: error)
       return self
     }
 
-    public func addBody(_ body: Data) -> Builder {
+    @discardableResult public func addBody(_ body: Data) -> Builder {
       assert(response != nil)
       response.body = body
       return self
     }
 
-    public func addHeader(withKey key: String, value: String) -> Builder {
+    @discardableResult public func addHeader(withKey key: String, value: String) -> Builder {
       assert(response != nil)
       response.headers[key] = value
       return self


### PR DESCRIPTION
Added the @discardableResult on builder functions to resolve compilation warnings when configuring the responsebuilder in several steps.
Ex: Result of call to 'stubResponse(withError:)' is unused