### PR TITLE
304 was incorrectly being redirected

### DIFF
--- a/Hippolyte/HTTPStubURLProtocol.swift
+++ b/Hippolyte/HTTPStubURLProtocol.swift
@@ -43,7 +43,7 @@ final class HTTPStubURLProtocol: URLProtocol {
       let response = HTTPURLResponse(url: url, statusCode: statusCode, httpVersion: nil,
                                      headerFields: stubbedResponse.headers)
 
-      if 300...399 ~= statusCode && (statusCode != 304 || statusCode != 305) {
+      if 300...399 ~= statusCode && (statusCode != 304 && statusCode != 305) {
         guard let location = stubbedResponse.headers["Location"], let url = URL(string: location),
               let cookies = cookieStorage.cookies(for: url) else {
                 return

--- a/HippolyteTests/HippolyteTests.swift
+++ b/HippolyteTests/HippolyteTests.swift
@@ -114,7 +114,7 @@ final class HippolyteTests: XCTestCase {
     let expectation = self.expectation(description: "Dies not stub network redirect call")
     let delegate = BlockRedirectDelegate()
     let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
-    let task = session.dataTask(with: url) { data, _, _ in
+    let task = session.dataTask(with: url) { _, _, _ in
       expectation.fulfill()
     }
     task.resume()

--- a/HippolyteTests/HippolyteTests.swift
+++ b/HippolyteTests/HippolyteTests.swift
@@ -101,6 +101,27 @@ final class HippolyteTests: XCTestCase {
     XCTAssertEqual(delegate.redirectCallCount, 1)
   }
 
+  func testItDoesNotStubsRedirectNoContent() {
+    let url = URL(string: "http://www.apple.com")!
+    var stub = StubRequest(method: .GET, url: url)
+    var response = StubResponse()
+    response = StubResponse(statusCode: 304)
+    stub.response = response
+    Hippolyte.shared.add(stubbedRequest: stub)
+
+    Hippolyte.shared.start()
+
+    let expectation = self.expectation(description: "Dies not stub network redirect call")
+    let delegate = BlockRedirectDelegate()
+    let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+    let task = session.dataTask(with: url) { data, _, _ in
+      expectation.fulfill()
+    }
+    task.resume()
+    wait(for: [expectation], timeout: 1)
+
+    XCTAssertEqual(delegate.redirectCallCount, 0)
+  }
 }
 
 final class BlockRedirectDelegate: NSObject, URLSessionDelegate, URLSessionTaskDelegate {


### PR DESCRIPTION
This fixes an issue that I found where 304 was not being handled properly.
https://github.com/JanGorman/Hippolyte/issues/43

Sorry if I did the fork / PR wrong here.
