### PR TITLE
added ability to create user defined matchers

### DIFF
--- a/Hippolyte/Matchers/Matcher.swift
+++ b/Hippolyte/Matchers/Matcher.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public class Matcher: Hashable {
+open class Matcher: Hashable {
 
   func matches(string: String?) -> Bool {
     false


### PR DESCRIPTION
Matcher class was defined with a public access specifier, to provide ability to make user defined matchers it should be defined as open