### PR TITLE
Use the request-specific HTTPCookieStorage if set.

### DIFF
--- a/Hippolyte/HTTPStubURLProtocol.swift
+++ b/Hippolyte/HTTPStubURLProtocol.swift
@@ -47,8 +47,8 @@ final class HTTPStubURLProtocol: URLProtocol {
     // gives us access to the URLSessionTask and its configuration.
     var cookieStorage = HTTPCookieStorage.shared
     if #available(iOS 8, *),
-       let configuration = task?.value(forKey: "configuration") as? URLSessionConfiguration,
-       let configurationCookieStorage = configuration.httpCookieStorage {
+       let session = task?.value(forKey: "session") as? URLSession,
+       let configurationCookieStorage = session.configuration.httpCookieStorage {
       cookieStorage = configurationCookieStorage
     }
 


### PR DESCRIPTION
Currently the shared HTTPCookieStorage is always used regardless of whether a HTTPCookieStorage is set in the URLSessionConfiguration.
This PR also adds cookies to the request headers before the StubRequest header matchers are run, so header matchers can match on the Cookies header.