### PR TITLE
Do not guard data before sending to bodyMatcher

### DIFF
--- a/Hippolyte/StubRequest.swift
+++ b/Hippolyte/StubRequest.swift
@@ -108,7 +108,7 @@ public struct StubRequest: Hashable {
   }
 
   private func matchesBody(_ body: Data?) -> Bool {
-    guard let bodyMatcher = bodyMatcher, let body = body else {
+    guard let bodyMatcher = bodyMatcher else {
       return true
     }
     return bodyMatcher.matches(data: body)

--- a/HippolyteTests/StubRequestTests.swift
+++ b/HippolyteTests/StubRequestTests.swift
@@ -89,6 +89,19 @@ final class StubRequestTests: XCTestCase {
 
     XCTAssertTrue(stub.matchesRequest(request))
   }
+  
+  func testBodyMatchesChecksNil() {
+    var stub = StubRequest(method: .GET, url: URL(string: "http://www.apple.com")!)
+    // Desired a "data" body.
+    stub.bodyMatcher = DataMatcher(data: Data("data".utf8))
+
+    var request = TestRequest(method: .GET, url: URL(string: "http://www.apple.com")!)
+    // The actual body is `nil`.
+    request.body = nil
+
+    // "data" body matcher should not match `nil`.
+    XCTAssertFalse(stub.matchesRequest(request))
+  }
 
   func testBuilderProducesStubs() throws {
     let builder = StubRequest.Builder()


### PR DESCRIPTION
`guard let body = body` in `matchesBody` prevents us from verifying the case a `nil` body is sent, but the request desires some data in the HTTP body.

As described in the test too.